### PR TITLE
transformer: Provide only the latest images

### DIFF
--- a/src/cloudimagedirectory/filter/filter.py
+++ b/src/cloudimagedirectory/filter/filter.py
@@ -4,6 +4,14 @@ import pandas as pd
 import pytz  # type: ignore
 
 
+def get_utc_datetime(date_string):
+    """Get a timezone-aware comparable UTC datetime object.
+
+    Returns: A datetime object representing the date string.
+    """
+    return pd.Timestamp(date_string).replace(tzinfo=pytz.UTC)
+
+
 def FilterImageByFilename(word: str) -> Callable:
     """Filter images by filename."""
     print("filter images by filename: " + word)
@@ -20,6 +28,44 @@ def FilterImageByLatestUpdate(latestDate: pd.Timestamp) -> Callable:
     return lambda data: [
         d
         for d in data
-        if d.content is not None
-        and pd.Timestamp(d.content["date"]).replace(tzinfo=pytz.UTC) > latestDate
+        if d.content is not None and get_utc_datetime(d.content["date"]) > latestDate
     ]
+
+
+def FilterImageByUniqueName() -> Callable:
+    """Filter latest images with unique names."""
+    print("filter images by unique names")
+    return _filter_by_unique_names
+
+
+def _filter_by_unique_names(data):
+    """Return a list of latest images with unique names."""
+    # Create a dictionary of image names and latest data entries.
+    # The dictionary ensures uniqueness of the names and preserves
+    # insertion order of the data entries.
+    unique_data = {}
+
+    for entry in data:
+        # Skip data entries without content.
+        if entry.content is None:
+            continue
+
+        # Compare the data entry with the last inserted entry of
+        # the same name. If the new entry is older, do nothing.
+        name = entry.content["name"]
+        date = entry.content["date"]
+
+        if name in unique_data:
+            latest_entry = unique_data[name]
+            latest_date = latest_entry.content["date"]
+
+            if get_utc_datetime(latest_date) > get_utc_datetime(date):
+                continue
+
+        # Add a new latest data entry for this image name.
+        # Reinsert the key to preserve the insertion order.
+        unique_data.pop(name, None)
+        unique_data[name] = entry
+
+    # Return a list of latest entries with unique image names.
+    return list(unique_data.values())

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -58,6 +58,7 @@ def run(
     filters = [
         filter.FilterImageByFilename("test"),
         filter.FilterImageByFilename("beta"),
+        filter.FilterImageByUniqueName(),
     ]
 
     if filter_until == "default":

--- a/tests/filter/test_filter.py
+++ b/tests/filter/test_filter.py
@@ -53,3 +53,87 @@ def test_filterImageByLatestUpdate():
     assert len(expected) == len(results)
     assert expected[0].content == results[0].content
     assert expected[1].content == results[1].content
+
+
+def test_FilterImageByUniqueName():
+    """Test for filtering latest images with unique names."""
+    data = [
+        connection.DataEntry(
+            "aws/region-1/rhel-1",
+            None,
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-3",
+            {
+                "name": "rhel-3",
+                "date": "2023-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-1",
+            {
+                "name": "rhel-1",
+                "date": "2020-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-2",
+            {
+                "name": "rhel-2",
+                "date": "2022-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-3",
+            {
+                "name": "rhel-3",
+                "date": "2022-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-3",
+            {
+                "name": "rhel-3",
+                "date": "2020-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "google/region-1/rhel-1",
+            {
+                "name": "rhel-1",
+                "date": "2024-01-01",
+            },
+        ),
+    ]
+    results = filter.FilterImageByUniqueName()(data)
+    expected = [
+        connection.DataEntry(
+            "azure/region-1/rhel-3",
+            {
+                "name": "rhel-3",
+                "date": "2023-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "azure/region-1/rhel-2",
+            {
+                "name": "rhel-2",
+                "date": "2022-01-01",
+            },
+        ),
+        connection.DataEntry(
+            "google/region-1/rhel-1",
+            {
+                "name": "rhel-1",
+                "date": "2024-01-01",
+            },
+        ),
+    ]
+
+    for r in results:
+        print(r.content)
+
+    assert len(expected) == len(results)
+    assert expected[0].content == results[0].content
+    assert expected[1].content == results[1].content
+    assert expected[2].content == results[2].content


### PR DESCRIPTION
If there are multiple images of the same name, use only the latest one. This is a workaround of an issue with the CID API, that generates files for these images at the same path and looses data about images as a result. Let's throw away the data anyway, but this time intentionally.

Resolves: #492