### PR TITLE
V2 list product #620

### DIFF
--- a/src/cloudimagedirectory/connection/connection.py
+++ b/src/cloudimagedirectory/connection/connection.py
@@ -31,6 +31,19 @@ class DataEntry:
         """Check the origin of the file."""
         return f"{name}/" in self.filename
 
+    def is_API(self, api) -> bool:
+        """Check if the file is the actual API entry and not a sub url."""
+        path = self.filename.split("/")
+        if path[1] != api:
+            return False
+        slash_count = self.filename.count("/")
+        if slash_count != 6:
+            return False
+        # NOTE: check length of hash value.
+        if len(path[len(path)-1]) != 40:
+            return False
+        
+        return True
 
 class ConnectionFS:
     """Handles the connection to the filesystem."""

--- a/src/cloudimagedirectory/connection/connection.py
+++ b/src/cloudimagedirectory/connection/connection.py
@@ -37,7 +37,7 @@ class DataEntry:
         if path[1] != api:
             return False
         slash_count = self.filename.count("/")
-        if slash_count != 6:
+        if slash_count != 11:
             return False
         # NOTE: check length of hash value.
         if len(path[len(path)-1]) != 40:

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -323,6 +323,7 @@ class TransformerV2All(Transformer):
         return [connection.DataEntry("v2/all", results)]
 
 
+
 class TransformerV2ListOS(Transformer):
     """Generate list of all available operating systems."""
 
@@ -395,3 +396,46 @@ class TransformerV2ListOS(Transformer):
             results.append(entry_object)
 
         return [connection.DataEntry("v2/os/list", results)]
+
+class TransformerV2ListProducts(Transformer):
+    """Generate a list for all available products in a specific os."""
+
+    def run(self, data):
+        """Sort the raw data."""
+        # NOTE: Verify that the data is not raw.
+        entries = [x for x in data if not x.is_raw() and not x.is_provided_by("idx")]
+
+        results = []
+        product_list = {}
+        os_list = {}
+
+        for e in entries:
+            entry = copy.deepcopy(e)
+            filename = entry.filename.split("/")[3]
+            os = filename.split("_")[0]
+
+            if os not in os_list:
+                os_list[os] = 1
+
+            try:
+                filename = entry.filename.split("/")[3]
+                if entry.is_provided_by("aws"):
+                    product = filename.split("_")[2]
+                    print("product aws: " + product)
+                elif entry.is_provided_by("azure"):
+                    product = filename.split("_")[0]
+                    print("product azure: " + product)
+                elif entry.is_provided_by("google"):
+                    product = filename.split("_")[2]
+                    print("product google: " + product)
+
+                if product not in product_list:
+                    product_list[product] = 1
+
+                print(product_list)
+                results.append(entry)
+
+            except:
+                print(f"Could not format image, filename: {filename}")
+
+        return []

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -87,8 +87,8 @@ class TransformerIdxListImageLatest(Transformer):
     @no_type_check
     def run(self, data: Transformer) -> list:  # noqa: C901
         """Sort the raw data."""
-        # NOTE: Verify that the data is not raw.
-        entries = [x for x in data if not x.is_raw() and not x.is_provided_by("idx")]
+        # NOTE: Verify that the data is from api v1.
+        entries = [x for x in data if x.is_API("v1")]
 
         # NOTE: Sort the list of data by date
         entries.sort(
@@ -283,9 +283,7 @@ class TransformerIdxListImageNames(Transformer):
     # TODO: Mypy says that 'data' below is not iterable. This needs to be fixed later.
     @no_type_check
     def run(self, data: type[Transformer]) -> list:
-        """Sort the raw data."""
-        # NOTE: Verify that the data is not raw.
-        entries = [x for x in data if not x.is_raw() and not x.is_provided_by("idx")]
+        entries = [x for x in data if x.is_API("v1")]
 
         results = []
 
@@ -303,9 +301,7 @@ class TransformerV2All(Transformer):
     # TODO: Mypy says that 'data' below is not iterable. This needs to be fixed later.
     @no_type_check
     def run(self, data: type[Transformer]) -> list:
-        """Sort the raw data."""
-        # NOTE: Verify that the data is not raw.
-        entries = [x for x in data if not x.is_raw() and not x.is_provided_by("idx")]
+        entries = [x for x in data if x.is_API("v2")]
 
         results = []
 
@@ -341,9 +337,7 @@ class TransformerV2ListOS(Transformer):
     # TODO: Mypy says that 'data' below is not iterable. This needs to be fixed later.
     @no_type_check
     def run(self, data: type[Transformer]) -> list:
-        """Sort the raw data."""
-        # NOTE: Verify that the data is not raw.
-        # TODO: check that its the actual v2 entry and not a sub url.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -363,14 +357,7 @@ class TransformerV2ListOS(Transformer):
             except IndexError:
                 print(f"Could not format image, filename: {filename}")
 
-        os_list_final: dict[Any, Any] = {}
-        for os, val in list(os_list.items()):
-            key = os
-            if os in rhel_products:
-                key = "rhel"
-            os_list_final[key] = os_list_final.get(key, 0) + val
-
-        for os, val in os_list_final.items():
+        for os, val in os_list.items():
             desc = self.description.get(os, "no description")
             disp_name = self.display_name.get(os, "no display name")
 
@@ -391,9 +378,7 @@ class TransformerV2ListProviderByOS(Transformer):
     """Generate a list for all available providers of a specific os."""
 
     def run(self, data):
-        """Sort the raw data."""
-        # NOTE: Verify that the data is not raw.
-        # TODO: check that its the actual v2 entry and not a sub url.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -423,7 +408,7 @@ class TransformerAWSV2RHEL(Transformer):
 
     def run(self, data):
         """Transform the raw data."""
-        # NOTE: Verify that the data is raw.
+        # NOTE: Verify that the data is raw and provided by aws.
         entries = [x for x in data if x.is_provided_by("aws") and x.is_raw()]
 
         results = []
@@ -460,7 +445,7 @@ class TransformerAzureV2RHEL(Transformer):
 
     def run(self, data):
         """Transform the raw data."""
-        # NOTE: Verify that the data is raw.
+        # NOTE: Verify that the data is raw and provided by azure.
         entries = [x for x in data if x.is_provided_by("azure") and x.is_raw()]
 
         results = []
@@ -499,7 +484,7 @@ class TransformerGoogleV2RHEL(Transformer):
 
     def run(self, data):
         """Transform the raw data."""
-        # NOTE: Verify that the data is raw.
+        # NOTE: Verify that the data is raw and provided by google.
         entries = [x for x in data if x.is_provided_by("google") and x.is_raw()]
 
         results = []
@@ -537,9 +522,7 @@ class TransformerV2ListOS(Transformer):
     display_name = {"rhel": "Red Hat Enterprise Linux"}
 
     def run(self, data):
-        """Sort the raw data."""
-        # NOTE: Verify that the data is the actual v2 entry and not a sub url.
-        # NOTE: This line is a workaround and should be revisited again.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -581,9 +564,7 @@ class TransformerV2ListProviderByOS(Transformer):
     """Generate a list for all available providers of a specific os."""
 
     def run(self, data):
-        """Sort the raw data."""
-        # NOTE: Verify that the data is the actual v2 entry and not a sub url.
-        # NOTE: This line is a workaround and should be revisited again.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -618,9 +599,7 @@ class TransformerV2ListVersionByProvider(Transformer):
     """Generate a list for all available versions for a specific provider."""
 
     def run(self, data):
-        """Sort the raw data."""
-        # NOTE: Verify that the data is the actual v2 entry and not a sub url.
-        # NOTE: This line is a workaround and should be revisited again.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -658,9 +637,7 @@ class TransformerV2ListRegionByVersion(Transformer):
     """Generate a list for all available regions for one version."""
 
     def run(self, data):
-        """Sort the raw data."""
-        # NOTE: Verify that the data is the actual v2 entry and not a sub url.
-        # NOTE: This line is a workaround and should be revisited again.
+        # TODO: check that its the v2 data entries.
         entries = [x for x in data if x.is_API("v2")]
 
         results = []
@@ -696,4 +673,53 @@ class TransformerV2ListRegionByVersion(Transformer):
                 for version in version_map:
                     # NOTE: Add /list suffix to prevent collision with "region" folder.
                     results.append(connection.DataEntry(f"v2/os/{os}/provider/{provider}/version/{version}/region/list", version_map[version]))
+        return results
+
+
+class TransformerV2ListImage(Transformer):
+    """Generate a list for all available images in this version."""
+
+    def run(self, data):
+        # TODO: check that its the v2 data entries.
+        entries = [x for x in data if x.is_API("v2")]
+
+        results = []
+        images = {}
+
+        for e in entries:
+            entry = copy.deepcopy(e)
+            filename = entry.filename.split("/")
+            if len(filename) != 11:
+                continue
+            os = filename[3]
+            provider = filename[5]
+            version = filename[7]
+            region = filename[9]
+            image = filename[11]
+
+            if os not in images:
+                images[os] = {provider : {}}
+
+            if provider not in images[os]:
+                images[os][provider] = {version : {}}
+            
+            if version not in images[os][provider]:
+                images[os][provider][version] = {region : {}}
+            
+            if region not in images[os][provider][version]:
+                images[os][provider][version][image] = {image : 1}
+
+            if region not in images[os][provider][version][image]:
+                images[os][provider][version][region] = 1
+                continue
+
+            # NOTE: Counter of how many images are available in this explicit version.
+            images[os][provider][version][region][image] += 1
+
+        for os, image_map in images.items():
+            for provider, version_map in image_map.items():
+                for version, region_map in version_map:
+                    for region in region_map:
+                        # NOTE: Add /list suffix to prevent collision with "image" folder.
+                        results.append(connection.DataEntry(f"v2/os/{os}/provider/{provider}/version/{version}/region/{region}/image/list", version_map[image]))
         return results

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -353,7 +353,7 @@ class TransformerV2ListOS(Transformer):
             entry = copy.deepcopy(e)
 
             try:
-                filename = entry.filename.split("/")[2]
+                filename = entry.filename.split("/")[3]
                 os = filename.split("_")[0]
 
                 if os not in os_list:
@@ -402,8 +402,8 @@ class TransformerV2ListProviderByOS(Transformer):
         for e in entries:
             entry = copy.deepcopy(e)
             filename = entry.filename.split("/")
-            os = filename[2]
-            provider = filename[3]
+            os = filename[3]
+            provider = filename[5]
             
             if provider not in providers or os not in providers[provider]:
                 providers[provider] = {os: 1}
@@ -415,7 +415,6 @@ class TransformerV2ListProviderByOS(Transformer):
         for provider, os_map in providers.items():
             for os in os_map:
                 results.append(connection.DataEntry(f"v2/os/{os}/provider/list", providers))
-
         return results    
 
 
@@ -449,8 +448,7 @@ class TransformerAWSV2RHEL(Transformer):
                 # NOTE: example of expected paths
                 # /v2/rhel/aws/8.6.0/eu-west-3/71d0a7aaa1f0dc06840e46f6ce316a7acfb022d4
                 # /v2/rhel/aws/8.2.0/eu-north-1/14e4eab326cc5a2ef13cb5c0f36bc9bfa41025d9
-                path = f"/v2/{os_name}/{provider}/{version}/{region}/{image_id}"
-                print(path)
+                path = f"/v2/os/{os_name}/provider/{provider}/version/{version}/region/{region}/image/{image_id}"
                 data_entry = connection.DataEntry(path, image_data)
 
                 results.append(data_entry)
@@ -489,8 +487,7 @@ class TransformerAzureV2RHEL(Transformer):
                 # NOTE: example of expected paths
                 # /v2/rhel/azure/8.6.0/af-south-1/71d0a7aaa1f0dc06840e46f6ce316a7acfb022d4
                 # /v2/rhel/azure/8.2.0/af-south-1/14e4eab326cc5a2ef13cb5c0f36bc9bfa41025d9
-                path = f"/v2/{os_name}/{provider}/{version}/{region}/{image_id}"
-                print(path)
+                path = f"/v2/os/{os_name}/provider/{provider}/version/{version}/region/{region}/image/{image_id}"
                 data_entry = connection.DataEntry(path, image_data)
 
                 results.append(data_entry)
@@ -526,8 +523,7 @@ class TransformerGoogleV2RHEL(Transformer):
                     # NOTE: example of expected paths
                     # /v2/rhel/google/8.6.0/global/71d0a7aaa1f0dc06840e46f6ce316a7acfb022d4
                     # /v2/rhel/google/8.2.0/global/14e4eab326cc5a2ef13cb5c0f36bc9bfa41025d9
-                    path = f"/v2/{os_name}/{provider}/{version}/{region}/{image_id}"
-                    print(path)
+                    path = f"/v2/os/{os_name}/provider/{provider}/version/{version}/region/{region}/image/{image_id}"
                     data_entry = connection.DataEntry(path, image_data)
 
                     results.append(data_entry)

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -70,7 +70,7 @@ def run(origin_path: str, destination_path: str, arg_files: str, filter_until: s
             #transform.TransformerAWS,
             #transform.TransformerAZURE,
             #transform.TransformerGoogle,
-            transform.TransformerAWSV2RHEL,
+            #transform.TransformerAWSV2RHEL,
             transform.TransformerAzureV2RHEL,
             transform.TransformerGoogleV2RHEL,
         ],
@@ -83,6 +83,8 @@ def run(origin_path: str, destination_path: str, arg_files: str, filter_until: s
             transform.TransformerV2All,
             transform.TransformerV2ListProviderByOS,
             transform.TransformerV2ListOS,
+            transform.TransformerV2ListVersionByProvider,
+            transform.TransformerV2ListRegionByVersion,
         ],
     )
     print("run pipeline")

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -67,21 +67,22 @@ def run(origin_path: str, destination_path: str, arg_files: str, filter_until: s
     pipeline = transform.Pipeline(
         origin_connection,
         [
-            transform.TransformerAWS,
-            transform.TransformerAZURE,
-            transform.TransformerGoogle,
+            #transform.TransformerAWS,
+            #transform.TransformerAZURE,
+            #transform.TransformerGoogle,
+            transform.TransformerAWSV2RHEL,
+            transform.TransformerAzureV2RHEL,
+            transform.TransformerGoogleV2RHEL,
         ],
         filters,
         [
-            transform.TransformerIdxListImageNames,
-            transform.TransformerIdxListImageLatest,
-            transform.TransformerIdxListImageLatestGoogle,
-            transform.TransformerIdxListImageLatestAWS,
-            transform.TransformerIdxListImageLatestAZURE,
+            #transform.TransformerIdxListImageLatest,
+            #transform.TransformerIdxListImageLatestGoogle,
+            #transform.TransformerIdxListImageLatestAWS,
+            #transform.TransformerIdxListImageLatestAZURE,
             transform.TransformerV2All,
+            transform.TransformerV2ListProviderByOS,
             transform.TransformerV2ListOS,
-            transform.TransformerV2ListProducts,
-
         ],
     )
     print("run pipeline")

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -80,6 +80,8 @@ def run(origin_path: str, destination_path: str, arg_files: str, filter_until: s
             transform.TransformerIdxListImageLatestAZURE,
             transform.TransformerV2All,
             transform.TransformerV2ListOS,
+            transform.TransformerV2ListProducts,
+
         ],
     )
     print("run pipeline")

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -67,24 +67,25 @@ def run(origin_path: str, destination_path: str, arg_files: str, filter_until: s
     pipeline = transform.Pipeline(
         origin_connection,
         [
-            #transform.TransformerAWS,
-            #transform.TransformerAZURE,
-            #transform.TransformerGoogle,
-            #transform.TransformerAWSV2RHEL,
+            transform.TransformerAWS,
+            transform.TransformerAZURE,
+            transform.TransformerGoogle,
+            transform.TransformerAWSV2RHEL,
             transform.TransformerAzureV2RHEL,
             transform.TransformerGoogleV2RHEL,
         ],
         filters,
         [
-            #transform.TransformerIdxListImageLatest,
-            #transform.TransformerIdxListImageLatestGoogle,
-            #transform.TransformerIdxListImageLatestAWS,
-            #transform.TransformerIdxListImageLatestAZURE,
+            transform.TransformerIdxListImageLatest,
+            transform.TransformerIdxListImageLatestGoogle,
+            transform.TransformerIdxListImageLatestAWS,
+            transform.TransformerIdxListImageLatestAZURE,
             transform.TransformerV2All,
             transform.TransformerV2ListProviderByOS,
             transform.TransformerV2ListOS,
             transform.TransformerV2ListVersionByProvider,
             transform.TransformerV2ListRegionByVersion,
+            transform.TransformerV2ListImage,
         ],
     )
     print("run pipeline")


### PR DESCRIPTION
https://github.com/redhatcloudx/transformer/pull/657/files
---
I tried to clean up my testing branch. ^^
To keep things simple, I temporary removed the product entry from the path. 
https://github.com/redhatcloudx/transformer/pull/657/files#diff-a91cd61896b60c524a10b1d797e8a78ed9c6242c1a2e15b26aac5e806a0c0974R428

I also hardcoded the OS, since the format image function can only handle `RHEL` raw data. Therefore I also named the v2 transformer for AWS `TransformerAWSV2RHEL`.

Currently the transformer for the other endpoints do not work as expected. Since the entry list contains not only the original v2 entries. 
https://github.com/redhatcloudx/transformer/pull/657/files#diff-a91cd61896b60c524a10b1d797e8a78ed9c6242c1a2e15b26aac5e806a0c0974R335
