### PR TITLE
linting: limix max mccabe complexity to 7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,10 @@ ignore = [
     "E731",
 ]
 
+[tool.ruff.mccabe]
+# Flag errors (`C901`) whenever the complexity level exceeds 5.
+max-complexity = 7
+
 [tool.pytest.ini_options]
 addopts = "-n auto --cov=src/cloudimagedirectory --cov-report=term-missing --cov-report=xml --cov-branch"
 testpaths = [


### PR DESCRIPTION
We have 3-4 functions now which are maxing out around 7, so set the limit there so we don't make anything more complex. 😉