### PR TITLE
Convert DataEntry to a dataclass

### DIFF
--- a/src/cloudimagedirectory/connection/connection.py
+++ b/src/cloudimagedirectory/connection/connection.py
@@ -1,9 +1,11 @@
 """Manage content in the S3 bucket."""
+from __future__ import annotations
+
 import json
 import os
 import pathlib
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 
 class OriginPathDoesNotExist(Exception):
@@ -14,14 +16,12 @@ class OriginPathDoesNotExist(Exception):
         super().__init__(f"The origin path '{origin_path}' doesn't exist.")
 
 
+@dataclass
 class DataEntry:
     """Handles a file from the bucket."""
 
-    # TODO: Set Any to a specific type.
-    def __init__(self, filename: str, content: Any) -> None:
-        """Constructor for DataEntry class."""
-        self.filename = filename
-        self.content = content
+    filename: str  # File name of the JSON file.
+    content: dict | None  # Content of the JSON file.
 
     def is_raw(self) -> bool:
         """Check if the file is in raw format."""
@@ -85,8 +85,8 @@ class ConnectionFS:
         content = Path(data.filename).read_text()
         if content == "":
             content = "{}"
-        content = json.loads(content)
-        return DataEntry(data.filename, content)
+        json_content = json.loads(content)
+        return DataEntry(data.filename, json_content)
 
     def put_content(self, data: DataEntry) -> None:
         """Put the content of a file in the bucket."""


### PR DESCRIPTION
This simplifies the DataEntry class a bit and allows us to have a really handy `__repr__` output whenever we need to print out the contents of the class.

Also, this fixes a mypy issue where `content` is recast from a string to a dictionary when `json.loads()` reads it.